### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           make coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3  # v5.3.1
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574  # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ThreatFlux/githubWorkFlowChecker


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `codecov/codecov-action`
  * From: 13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 (13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3)
  * To: v5.4.0 (0565863a31f2c772f9f0395002a31e3f06189574)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.