### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Set up Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
           go-version: '1.24.1'
           check-latest: true
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
           go-version: '1.24.1'
           check-latest: true
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
           go-version: '1.24.1'
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
           go-version: '1.24.1'
           cache: true

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
           go-version: '1.24.1'
           check-latest: true


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/setup-go`
  * From: 0aaccfd150d50ccaeb58ebd88d36e91967a5f35b (0aaccfd150d50ccaeb58ebd88d36e91967a5f35b)
  * To: v5.5.0 (d35c59abb061a4a6fb18e82ac0862c26744d6ab5)

* `actions/setup-go`
  * From: 0aaccfd150d50ccaeb58ebd88d36e91967a5f35b (0aaccfd150d50ccaeb58ebd88d36e91967a5f35b)
  * To: v5.5.0 (d35c59abb061a4a6fb18e82ac0862c26744d6ab5)

* `actions/setup-go`
  * From: 0aaccfd150d50ccaeb58ebd88d36e91967a5f35b (0aaccfd150d50ccaeb58ebd88d36e91967a5f35b)
  * To: v5.5.0 (d35c59abb061a4a6fb18e82ac0862c26744d6ab5)

* `actions/setup-go`
  * From: 0aaccfd150d50ccaeb58ebd88d36e91967a5f35b (0aaccfd150d50ccaeb58ebd88d36e91967a5f35b)
  * To: v5.5.0 (d35c59abb061a4a6fb18e82ac0862c26744d6ab5)

* `actions/setup-go`
  * From: 0aaccfd150d50ccaeb58ebd88d36e91967a5f35b (0aaccfd150d50ccaeb58ebd88d36e91967a5f35b)
  * To: v5.5.0 (d35c59abb061a4a6fb18e82ac0862c26744d6ab5)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.