### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           make coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24  # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ThreatFlux/githubWorkFlowChecker


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `codecov/codecov-action`
  * From: ad3126e916f78f00edff4ed0317cf185271ccc2d (ad3126e916f78f00edff4ed0317cf185271ccc2d)
  * To: v5.4.3 (18283e04ce6e62d37312384ff67231eb8fd56d24)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.