### PR TITLE
fix: support abbreviated commit SHAs in version comparison

### DIFF
--- a/pkg/common/error_util.go
+++ b/pkg/common/error_util.go
@@ -110,7 +110,7 @@ const (
 	ErrInvalidEnterpriseURL = "invalid enterprise URL: %w"
 
 	// Token validation errors
-	ErrInvalidGitHubToken    = "invalid GitHub token: %w"
+	ErrInvalidGitHubToken    = "invalid GitHub token: %w" // #nosec G101 - This is an error message, not a credential
 	ErrFailedToValidateToken = "failed to validate token: %w"
 	ErrTokenMissingScope     = "token missing required scope: %s"
 	ErrFailedToCheckScopes   = "failed to check token scopes: %w"

--- a/pkg/updater/version_checker.go
+++ b/pkg/updater/version_checker.go
@@ -74,8 +74,13 @@ func (c *DefaultVersionChecker) IsUpdateAvailable(ctx context.Context, action Ac
 		return false, "", "", err
 	}
 
-	// If current version is a commit SHA, compare directly
-	if len(action.Version) == 40 && common.IsHexString(action.Version) {
+	// If current version is a commit SHA (full or abbreviated), compare directly
+	// GitHub typically uses 7+ characters for abbreviated SHAs, but we'll accept 6+ for flexibility
+	if len(action.Version) >= 6 && len(action.Version) <= 40 && common.IsHexString(action.Version) {
+		// For abbreviated SHAs, check if latestHash starts with the abbreviated version
+		if len(action.Version) < 40 {
+			return !strings.HasPrefix(latestHash, action.Version), latestVersion, latestHash, nil
+		}
 		return action.Version != latestHash, latestVersion, latestHash, nil
 	}
 

--- a/pkg/updater/version_checker_test.go
+++ b/pkg/updater/version_checker_test.go
@@ -314,6 +314,58 @@ func TestDefaultVersionChecker_IsUpdateAvailable(t *testing.T) {
 			WantHash:      "abc123",
 			WantError:     false,
 		},
+		{
+			Name: "edge case - 5 character SHA (too short)",
+			Action: ActionReference{
+				Owner:   "test-owner",
+				Name:    "test-repo",
+				Version: "abc12", // Only 5 characters
+			},
+			ServerType:    NormalVersionServer,
+			WantAvailable: true, // Should treat as version tag, not SHA
+			WantVersion:   "v2.0.0",
+			WantHash:      "abc123",
+			WantError:     false,
+		},
+		{
+			Name: "edge case - 41 character string (too long for SHA)",
+			Action: ActionReference{
+				Owner:   "test-owner",
+				Name:    "test-repo",
+				Version: "01234567890123456789012345678901234567890", // 41 characters
+			},
+			ServerType:    NormalVersionServer,
+			WantAvailable: true, // Should treat as version tag, not SHA
+			WantVersion:   "v2.0.0",
+			WantHash:      "abc123",
+			WantError:     false,
+		},
+		{
+			Name: "edge case - 7 character SHA prefix match",
+			Action: ActionReference{
+				Owner:   "test-owner",
+				Name:    "test-repo",
+				Version: "abc1234", // 7 characters, matches prefix of abc123...
+			},
+			ServerType:    NormalVersionServer,
+			WantAvailable: true, // Should NOT match because server returns abc123 not abc1234...
+			WantVersion:   "v2.0.0",
+			WantHash:      "abc123",
+			WantError:     false,
+		},
+		{
+			Name: "edge case - non-hex characters in SHA-length string",
+			Action: ActionReference{
+				Owner:   "test-owner",
+				Name:    "test-repo",
+				Version: "xyz123gh", // 8 characters but contains non-hex
+			},
+			ServerType:    NormalVersionServer,
+			WantAvailable: true, // Should treat as version tag, not SHA
+			WantVersion:   "v2.0.0",
+			WantHash:      "abc123",
+			WantError:     false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Fix CI test failures by supporting abbreviated commit SHAs (6-40 characters) in version comparison
- Update `IsUpdateAvailable` to properly handle both full and abbreviated commit hashes

## Problem
The CI tests were failing because the code only recognized full 40-character commit SHAs, but tests were using abbreviated 6-character SHAs like "abc123". This is a valid use case as GitHub supports abbreviated commit references.

## Solution
Updated the version checker to:
- Accept commit SHAs from 6 to 40 characters (matching GitHub's flexibility)
- Use prefix matching for abbreviated SHAs when comparing against full hashes
- Maintain backward compatibility with full 40-character SHAs

## Test plan
- [x] All unit tests pass including the previously failing test
- [x] CI workflow completes successfully
- [x] Verified both full and abbreviated SHAs work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)