### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
           ' CHANGELOG.md > release_notes.md
 
       - name: Upload Release Assets
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631  # v2.2.2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8  # v2.3.2
         with:
           files: |
             ghactions-updater-linux-amd64


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `softprops/action-gh-release`
  * From: da05d552573ad5aba039eaac05058a918a7bf631 (da05d552573ad5aba039eaac05058a918a7bf631)
  * To: v2.3.2 (72f2c25fcb47643c292f7107632f7a47c1df5cd8)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.