### PR TITLE
Use Go 1.25.0 Alpine images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 # Build stage
-FROM golang:1.25-rc-alpine3.21 AS builder
+FROM golang:1.25.0-alpine3.21 AS builder
 
 # Build arguments
 ARG VERSION=development

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 # Development image with all required tools for Go development
-FROM golang:1.25-rc-alpine3.21
+FROM golang:1.25.0-alpine3.21
 
 # Build arguments
 ARG USER=goapp


### PR DESCRIPTION
## Summary
- use final Go 1.25.0 release for builder image
- update development container to Go 1.25.0

## Testing
- `go fmt ./pkg/...`
- `golangci-lint run ./...` *(fails: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0))*
- `GITHUB_TOKEN=dummy go test ./pkg/...` *(fails: failed to get repository: 401 Bad credentials)*

------
https://chatgpt.com/codex/tasks/task_e_689c15c75158832783fdb0c285766cf5