### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0  # Fetch all history for all branches
 
@@ -102,7 +102,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
         with:
@@ -31,7 +31,7 @@ jobs:
           make coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24  # v5.4.3
+        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00  # v5.5.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ThreatFlux/githubWorkFlowChecker
@@ -41,7 +41,7 @@ jobs:
     needs: [test-unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
@@ -57,7 +57,7 @@ jobs:
     needs: [security-scan]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `codecov/codecov-action`
  * From: 18283e04ce6e62d37312384ff67231eb8fd56d24 (18283e04ce6e62d37312384ff67231eb8fd56d24)
  * To: v5.5.0 (fdcc8476540edceab3de004e990f80d881c6cc00)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

* `actions/checkout`
  * From: 11bd71901bbe5b1630ceea73d27597364c9af683 (11bd71901bbe5b1630ceea73d27597364c9af683)
  * To: v5.0.0 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.