### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: make docker-build
 
       - name: Upload binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5.0.0
         with:
           name: ghactions-updater
           path: bin/ghactions-updater

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
     steps:
       - name: Wait for tests
-        uses: lewagon/wait-on-check-action@0dceb95e7c4cad8cc7422aee3885998f5cab9c79  # v1.4.0
+        uses: lewagon/wait-on-check-action@3603e826ee561ea102b58accb5ea55a1a7482343  # v1.4.1
         with:
           ref: ${{ github.ref }}
           check-name: 'Test'
@@ -136,7 +136,7 @@ jobs:
           ' CHANGELOG.md > release_notes.md
 
       - name: Upload Release Assets
-        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8  # v2.3.2
+        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090  # v2.4.1
         with:
           files: |
             ghactions-updater-linux-amd64


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/upload-artifact`
  * From: ea165f8d65b6e75b540449e92b4886f43607fa02 (ea165f8d65b6e75b540449e92b4886f43607fa02)
  * To: v5.0.0 (330a01c490aca151604b8cf639adc76d48f6c5d4)

* `lewagon/wait-on-check-action`
  * From: 0dceb95e7c4cad8cc7422aee3885998f5cab9c79 (0dceb95e7c4cad8cc7422aee3885998f5cab9c79)
  * To: v1.4.1 (3603e826ee561ea102b58accb5ea55a1a7482343)

* `softprops/action-gh-release`
  * From: 72f2c25fcb47643c292f7107632f7a47c1df5cd8 (72f2c25fcb47643c292f7107632f7a47c1df5cd8)
  * To: v2.4.1 (6da8fa9354ddfdc4aeace5fc48d7f679b5214090)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.