### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0  # Fetch all history for all branches
 
@@ -102,7 +102,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
           go-version: '1.25.0'
           check-latest: true
@@ -31,7 +31,7 @@ jobs:
           make coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7  # v5.5.1
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ThreatFlux/githubWorkFlowChecker
@@ -41,10 +41,10 @@ jobs:
     needs: [test-unit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
           go-version: '1.25.0'
           check-latest: true
@@ -57,10 +57,10 @@ jobs:
     needs: [security-scan]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
           go-version: '1.25.0'
           check-latest: true
@@ -72,7 +72,7 @@ jobs:
         run: make docker-build
 
       - name: Upload binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: ghactions-updater
           path: bin/ghactions-updater

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
     steps:
       - name: Wait for tests
-        uses: lewagon/wait-on-check-action@0dceb95e7c4cad8cc7422aee3885998f5cab9c79  # v1.4.0
+        uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c  # v1.5.0
         with:
           ref: ${{ github.ref }}
           check-name: 'Test'
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
           go-version: '1.25.0'
           cache: true
@@ -136,7 +136,7 @@ jobs:
           ' CHANGELOG.md > release_notes.md
 
       - name: Upload Release Assets
-        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8  # v2.3.2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
           files: |
             ghactions-updater-linux-amd64

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -13,10 +13,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
           go-version: '1.25.0'
           check-latest: true


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/checkout`
  * From: 08c6903cd8c0fde910a37f88322edcfb5dd907a8 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)
  * To: v6.0.2 (de0fac2e4500dabe0009e67214ff5f5447ce83dd)

* `actions/checkout`
  * From: 08c6903cd8c0fde910a37f88322edcfb5dd907a8 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)
  * To: v6.0.2 (de0fac2e4500dabe0009e67214ff5f5447ce83dd)

* `actions/checkout`
  * From: 08c6903cd8c0fde910a37f88322edcfb5dd907a8 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)
  * To: v6.0.2 (de0fac2e4500dabe0009e67214ff5f5447ce83dd)

* `actions/setup-go`
  * From: 44694675825211faa026b3c33043df3e48a5fa00 (44694675825211faa026b3c33043df3e48a5fa00)
  * To: v6.3.0 (4b73464bb391d4059bd26b0524d20df3927bd417)

* `codecov/codecov-action`
  * From: 5a1091511ad55cbe89839c7260b706298ca349f7 (5a1091511ad55cbe89839c7260b706298ca349f7)
  * To: v5.5.2 (671740ac38dd9b0130fbe1cec585b89eea48d3de)

* `actions/checkout`
  * From: 08c6903cd8c0fde910a37f88322edcfb5dd907a8 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)
  * To: v6.0.2 (de0fac2e4500dabe0009e67214ff5f5447ce83dd)

* `actions/setup-go`
  * From: 44694675825211faa026b3c33043df3e48a5fa00 (44694675825211faa026b3c33043df3e48a5fa00)
  * To: v6.3.0 (4b73464bb391d4059bd26b0524d20df3927bd417)

* `actions/checkout`
  * From: 08c6903cd8c0fde910a37f88322edcfb5dd907a8 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)
  * To: v6.0.2 (de0fac2e4500dabe0009e67214ff5f5447ce83dd)

* `actions/setup-go`
  * From: 44694675825211faa026b3c33043df3e48a5fa00 (44694675825211faa026b3c33043df3e48a5fa00)
  * To: v6.3.0 (4b73464bb391d4059bd26b0524d20df3927bd417)

* `actions/upload-artifact`
  * From: ea165f8d65b6e75b540449e92b4886f43607fa02 (ea165f8d65b6e75b540449e92b4886f43607fa02)
  * To: v7.0.0 (bbbca2ddaa5d8feaa63e36b76fdaad77386f024f)

* `lewagon/wait-on-check-action`
  * From: 0dceb95e7c4cad8cc7422aee3885998f5cab9c79 (0dceb95e7c4cad8cc7422aee3885998f5cab9c79)
  * To: v1.5.0 (74049309dfeff245fe8009a0137eacf28136cb3c)

* `actions/checkout`
  * From: 08c6903cd8c0fde910a37f88322edcfb5dd907a8 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)
  * To: v6.0.2 (de0fac2e4500dabe0009e67214ff5f5447ce83dd)

* `actions/setup-go`
  * From: 44694675825211faa026b3c33043df3e48a5fa00 (44694675825211faa026b3c33043df3e48a5fa00)
  * To: v6.3.0 (4b73464bb391d4059bd26b0524d20df3927bd417)

* `softprops/action-gh-release`
  * From: 72f2c25fcb47643c292f7107632f7a47c1df5cd8 (72f2c25fcb47643c292f7107632f7a47c1df5cd8)
  * To: v2.5.0 (a06a81a03ee405af7f2048a818ed3f03bbf83c7b)

* `actions/checkout`
  * From: 08c6903cd8c0fde910a37f88322edcfb5dd907a8 (08c6903cd8c0fde910a37f88322edcfb5dd907a8)
  * To: v6.0.2 (de0fac2e4500dabe0009e67214ff5f5447ce83dd)

* `actions/setup-go`
  * From: 44694675825211faa026b3c33043df3e48a5fa00 (44694675825211faa026b3c33043df3e48a5fa00)
  * To: v6.3.0 (4b73464bb391d4059bd26b0524d20df3927bd417)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.